### PR TITLE
Populate InvokedSagas Header

### DIFF
--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests/ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests.csproj
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests/ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests.csproj
@@ -60,6 +60,7 @@
     <Compile Include="SagaChangeOutput.cs" />
     <Compile Include="SagaUpdatedMessage.cs" />
     <Compile Include="ScenarioDescriptors\EnvironmentHelper.cs" />
+    <Compile Include="When_a_message_is_handled_by_a_saga.cs" />
     <Compile Include="When_saga_changes_state.cs" />
     <Compile Include="EndpointTemplates\ConfigureExtensions.cs" />
     <Compile Include="EndpointTemplates\DefaultServer.cs" />

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests/When_a_message_is_handled_by_a_saga.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests/When_a_message_is_handled_by_a_saga.cs
@@ -14,7 +14,7 @@
     public class When_a_message_is_handled_by_a_saga : NServiceBusAcceptanceTest
     {
         [Test]
-        public async Task Should_populate_InvokedSagas_header_for_audits()
+        public async Task Should_populate_InvokedSagas_header_for_single_saga_audits()
         {
             var context = await Scenario.Define<Context>()
                 .WithEndpoint<FakeServiceControl>()
@@ -32,7 +32,32 @@
             Assert.AreEqual($"{typeof(EndpointWithASaga.TheEndpointsSaga).FullName}:{context.SagaId}", invokedSagasHeaderValue);
         }
 
+        [Test]
+        public async Task Should_populate_InvokedSagas_header_for_multiple_saga_audits()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<FakeServiceControl>()
+                .WithEndpoint<EndpointWithASaga>(b => b.When((messageSession, ctx) =>
+                    messageSession.SendLocal(new MessageToBeAuditedByMultiple
+                    {
+                        Id = ctx.TestRunId
+                    })
+                ))
+                .Done(c => c.MessageAudited)
+                .Run();
+
+            string invokedSagasHeaderValue;
+            Assert.IsTrue(context.Headers.TryGetValue(SagaAuditHeaders.InvokedSagas, out invokedSagasHeaderValue), "InvokedSagas header is missing");
+            Assert.IsTrue(invokedSagasHeaderValue.Contains($"{typeof(EndpointWithASaga.TheEndpointsSaga).FullName}:{context.SagaId}"), "TheEndpointsSaga header value is missing");
+            Assert.IsTrue(invokedSagasHeaderValue.Contains($"{typeof(EndpointWithASaga.TheEndpointsSagaAlternative).FullName}:{context.AlternativeSagaId}"), "TheEndpointsSagaAlternative header value is missing");
+        }
+
         class MessageToBeAudited : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+
+        class MessageToBeAuditedByMultiple : ICommand
         {
             public Guid Id { get; set; }
         }
@@ -42,6 +67,7 @@
             public bool MessageAudited { get; set; }
             public IReadOnlyDictionary<string, string> Headers { get; set; }
             public Guid SagaId { get; set; }
+            public Guid AlternativeSagaId { get; set; }
         }
 
         class EndpointWithASaga : EndpointConfigurationBuilder
@@ -57,13 +83,14 @@
                 });
             }
 
-            public class TheEndpointsSaga : Saga<TheEndpointsSagaData>, IAmStartedByMessages<MessageToBeAudited>
+            public class TheEndpointsSaga : Saga<TheEndpointsSagaData>, IAmStartedByMessages<MessageToBeAudited>, IAmStartedByMessages<MessageToBeAuditedByMultiple>
             {
                 public Context TestContext { get; set; }
 
                 protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TheEndpointsSagaData> mapper)
                 {
                     mapper.ConfigureMapping<MessageToBeAudited>(msg => msg.Id).ToSaga(saga => saga.TestRunId);
+                    mapper.ConfigureMapping<MessageToBeAuditedByMultiple>(msg => msg.Id).ToSaga(saga => saga.TestRunId);
                 }
 
 
@@ -73,9 +100,39 @@
                     TestContext.SagaId = Data.Id;
                     return Task.FromResult(0);
                 }
+
+                public Task Handle(MessageToBeAuditedByMultiple message, IMessageHandlerContext context)
+                {
+                    Data.TestRunId = message.Id;
+                    TestContext.SagaId = Data.Id;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class TheEndpointsSagaAlternative : Saga<TheEndpointsSagaAlternativeData>, IAmStartedByMessages<MessageToBeAuditedByMultiple>
+            {
+                public Context TestContext { get; set; }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TheEndpointsSagaAlternativeData> mapper)
+                {
+                    mapper.ConfigureMapping<MessageToBeAuditedByMultiple>(msg => msg.Id).ToSaga(saga => saga.TestRunId);
+                }
+
+
+                public Task Handle(MessageToBeAuditedByMultiple message, IMessageHandlerContext context)
+                {
+                    Data.TestRunId = message.Id;
+                    TestContext.AlternativeSagaId = Data.Id;
+                    return Task.FromResult(0);
+                }
             }
 
             public class TheEndpointsSagaData : ContainSagaData
+            {
+                public Guid TestRunId { get; set; }
+            }
+
+            public class TheEndpointsSagaAlternativeData : ContainSagaData
             {
                 public Guid TestRunId { get; set; }
             }
@@ -93,11 +150,18 @@
                 });
             }
 
-            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>, IHandleMessages<MessageToBeAuditedByMultiple>
             {
                 public Context TestContext { get; set; }
 
                 public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
+                {
+                    TestContext.MessageAudited = true;
+                    TestContext.Headers = context.MessageHeaders;
+                    return Task.FromResult(0);
+                }
+
+                public Task Handle(MessageToBeAuditedByMultiple message, IMessageHandlerContext context)
                 {
                     TestContext.MessageAudited = true;
                     TestContext.Headers = context.MessageHeaders;

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests/When_a_message_is_handled_by_a_saga.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests/When_a_message_is_handled_by_a_saga.cs
@@ -1,0 +1,109 @@
+﻿namespace ServiceControl.Plugin.Nsb6.SagaAudit.AcceptanceTests
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using EndpointPlugin.Messages.SagaState;
+    using NServiceBus;
+    using NServiceBus.AcceptanceTesting;
+    using NServiceBus.AcceptanceTests;
+    using NServiceBus.AcceptanceTests.EndpointTemplates;
+    using NUnit.Framework;
+    using Plugin.SagaAudit;
+
+    public class When_a_message_is_handled_by_a_saga : NServiceBusAcceptanceTest
+    {
+        [Test]
+        public async Task Should_populate_InvokedSagas_header_for_audits()
+        {
+            var context = await Scenario.Define<Context>()
+                .WithEndpoint<FakeServiceControl>()
+                .WithEndpoint<EndpointWithASaga>(b => b.When((messageSession, ctx) =>
+                    messageSession.SendLocal(new MessageToBeAudited
+                    {
+                        Id = ctx.TestRunId
+                    })
+                ))
+                .Done(c => c.MessageAudited)
+                .Run();
+
+            string invokedSagasHeaderValue;
+            Assert.IsTrue(context.Headers.TryGetValue(SagaAuditHeaders.InvokedSagas, out invokedSagasHeaderValue), "InvokedSagas header is missing");
+            Assert.AreEqual($"{typeof(EndpointWithASaga.TheEndpointsSaga).FullName}:{context.SagaId}", invokedSagasHeaderValue);
+        }
+
+        class MessageToBeAudited : ICommand
+        {
+            public Guid Id { get; set; }
+        }
+
+        class Context : ScenarioContext
+        {
+            public bool MessageAudited { get; set; }
+            public IReadOnlyDictionary<string, string> Headers { get; set; }
+            public Guid SagaId { get; set; }
+        }
+
+        class EndpointWithASaga : EndpointConfigurationBuilder
+        {
+            public EndpointWithASaga()
+            {
+                var receiverEndpoint = NServiceBus.AcceptanceTesting.Customization.Conventions.EndpointNamingConvention(typeof(FakeServiceControl));
+
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<JsonSerializer>();
+                    c.AuditProcessedMessagesTo(receiverEndpoint);
+                });
+            }
+
+            public class TheEndpointsSaga : Saga<TheEndpointsSagaData>, IAmStartedByMessages<MessageToBeAudited>
+            {
+                public Context TestContext { get; set; }
+
+                protected override void ConfigureHowToFindSaga(SagaPropertyMapper<TheEndpointsSagaData> mapper)
+                {
+                    mapper.ConfigureMapping<MessageToBeAudited>(msg => msg.Id).ToSaga(saga => saga.TestRunId);
+                }
+
+
+                public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
+                {
+                    Data.TestRunId = message.Id;
+                    TestContext.SagaId = Data.Id;
+                    return Task.FromResult(0);
+                }
+            }
+
+            public class TheEndpointsSagaData : ContainSagaData
+            {
+                public Guid TestRunId { get; set; }
+            }
+        }
+
+        class FakeServiceControl : EndpointConfigurationBuilder
+        {
+            public FakeServiceControl()
+            {
+                IncludeType<SagaUpdatedMessage>();
+
+                EndpointSetup<DefaultServer>(c =>
+                {
+                    c.UseSerialization<JsonSerializer>();
+                });
+            }
+
+            public class MessageToBeAuditedHandler : IHandleMessages<MessageToBeAudited>
+            {
+                public Context TestContext { get; set; }
+
+                public Task Handle(MessageToBeAudited message, IMessageHandlerContext context)
+                {
+                    TestContext.MessageAudited = true;
+                    TestContext.Headers = context.MessageHeaders;
+                    return Task.FromResult(0);
+                }
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest/MasterSaga.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest/MasterSaga.cs
@@ -6,7 +6,8 @@ namespace ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest
     using NServiceBus.Logging;
 
     class MasterSaga : Saga<MasterSagaData>,
-        IAmStartedByMessages<StartMaster>,
+        IAmStartedByMessages<StartMasterAlpha>,
+        IAmStartedByMessages<StartMasterBeta>,
         IHandleTimeouts<MasterTimedOut>,
         IHandleMessages<WorkRequestedAt>,
         IHandleMessages<ChildFinished>
@@ -15,26 +16,55 @@ namespace ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest
 
         protected override void ConfigureHowToFindSaga(SagaPropertyMapper<MasterSagaData> mapper)
         {
-            mapper.ConfigureMapping<StartMaster>(msg => msg.Identifier).ToSaga(saga => saga.Identifier);
+            mapper.ConfigureMapping<StartMasterAlpha>(msg => msg.Identifier).ToSaga(saga => saga.Identifier);
+            mapper.ConfigureMapping<StartMasterBeta>(msg => msg.Identifier).ToSaga(saga => saga.Identifier);
             mapper.ConfigureMapping<WorkRequestedAt>(msg => msg.Identifier).ToSaga(saga => saga.Identifier);
             mapper.ConfigureMapping<ChildFinished>(msg => msg.Identifier).ToSaga(saga => saga.Identifier);
         }
 
-        public Task Handle(StartMaster message, IMessageHandlerContext context)
+        public Task Handle(StartMasterAlpha message, IMessageHandlerContext context)
         {
             Data.Identifier = message.Identifier;
-            Data.StartedAt = DateTime.UtcNow;
+            Data.AlphaReceived = true;
+            Data.WorkRequired = message.WorkRequired;
 
-            Log.Info($"Master {Data.Identifier} started.");
+            if (!Data.BetaReceived)
+            {
+                Data.StartedAt = DateTime.UtcNow;
+                Log.Info($"Master {Data.Identifier} started with Alpha.");
+            }
 
-            return Task.WhenAll(
-                context.SendLocal(new StartChild
-                {
-                    Identifier = message.Identifier,
-                    WorkRequired = message.WorkRequired
-                }),
-                RequestTimeout<MasterTimedOut>(context, DateTime.UtcNow.AddSeconds(2))
-            );
+            return CheckIfReadyToStart(context);
+        }
+
+        public Task Handle(StartMasterBeta message, IMessageHandlerContext context)
+        {
+            Data.Identifier = message.Identifier;
+            Data.BetaReceived = true;
+
+            if (!Data.AlphaReceived)
+            {
+                Data.StartedAt = DateTime.UtcNow;
+                Log.Info($"Master {Data.Identifier} started with Beta.");
+            }
+
+            return CheckIfReadyToStart(context);
+        }
+
+        Task CheckIfReadyToStart(IMessageHandlerContext context)
+        {
+            if (Data.AlphaReceived && Data.BetaReceived)
+            {
+                return Task.WhenAll(
+                    context.SendLocal(new StartChild
+                    {
+                        Identifier = Data.Identifier,
+                        WorkRequired = Data.WorkRequired
+                    }),
+                    RequestTimeout<MasterTimedOut>(context, DateTime.UtcNow.AddSeconds(2))
+                    );
+            }
+            return Task.FromResult(0);
         }
 
         public Task Timeout(MasterTimedOut state, IMessageHandlerContext context)

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest/MasterSagaData.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest/MasterSagaData.cs
@@ -8,5 +8,8 @@ namespace ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest
         public Guid Identifier { get; set; }
         public DateTime? LastWorkRequestedAt { get; set; }
         public DateTime StartedAt { get; set; }
+        public bool AlphaReceived { get; set; }
+        public bool BetaReceived { get; set; }
+        public int WorkRequired { get; set; }
     }
 }

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest/Program.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest/Program.cs
@@ -47,11 +47,14 @@ namespace ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest
                     var masterId = Guid.NewGuid();
                     masters.TryAdd(masterId, false);
                     Console.WriteLine($"Sending StartMaster for {masterId}");
-                    await endpoint.SendLocal(new StartMaster
+                    await Task.WhenAll(endpoint.SendLocal(new StartMasterAlpha
                     {
                         Identifier = masterId,
                         WorkRequired = i
-                    });
+                    }), endpoint.SendLocal(new StartMasterBeta
+                    {
+                        Identifier = masterId
+                    }));
                 }
                 do
                 {

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest/StartMaster.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.SmokeTest/StartMaster.cs
@@ -3,9 +3,14 @@
     using System;
     using NServiceBus;
 
-    class StartMaster : ICommand
+    class StartMasterAlpha : ICommand
     {
         public Guid Identifier { get; set; }
         public int WorkRequired { get; set; }
+    }
+
+    class StartMasterBeta : ICommand
+    {
+        public Guid Identifier { get; set; }
     }
 }

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.Tests/When_a_message_with_no_headers_arrive.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.Tests/When_a_message_with_no_headers_arrive.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using NServiceBus.Settings;
     using NUnit.Framework;
     using Plugin.SagaAudit;
 
@@ -11,14 +10,11 @@
         [Test]
         public void Saga_state_change_message_can_be_created()
         {
-            var settings = new SettingsHolder();
-            settings.Set("NServiceBus.Routing.EndpointName", "NA");
-            var behavior = new CaptureSagaStateBehavior(settings, null, null);
             var headers = new Dictionary<string, string>();
             var messageId = Guid.NewGuid().ToString();
             var messageType = "SomeMessage";
 
-            var message = behavior.BuildSagaChangeInitiatorMessage(headers, messageId, messageType);
+            var message = CaptureSagaStateBehavior.BuildSagaChangeInitiatorMessage(headers, messageId, messageType);
 
             Assert.IsNotNull(message);
             Assert.IsNull(message.OriginatingEndpoint);

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit.Tests/When_a_message_with_proper_headers_arrive.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit.Tests/When_a_message_with_proper_headers_arrive.cs
@@ -2,7 +2,6 @@
 {
     using System;
     using System.Collections.Generic;
-    using NServiceBus.Settings;
     using NUnit.Framework;
     using Plugin.SagaAudit;
 
@@ -11,10 +10,6 @@
         [Test]
         public void Saga_state_change_message_can_be_created()
         {
-            var settings = new SettingsHolder();
-            settings.Set("NServiceBus.Routing.EndpointName", "NA");
-            var behavior = new CaptureSagaStateBehavior(settings, null, null);
-
             var headers = new Dictionary<string, string>
             {
                 {"NServiceBus.MessageId", "cf79765e-0123-45bf-a41b-a42d00a867c9"},
@@ -41,7 +36,7 @@
             var messageId = Guid.NewGuid().ToString();
             const string messageType = "Message1";
 
-            var message = behavior.BuildSagaChangeInitiatorMessage(headers, messageId, messageType);
+            var message = CaptureSagaStateBehavior.BuildSagaChangeInitiatorMessage(headers, messageId, messageType);
 
             Assert.IsNotNull(message);
             Assert.IsNotNull(message.OriginatingEndpoint);

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit/AuditInvokedSagaBehavior.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit/AuditInvokedSagaBehavior.cs
@@ -1,0 +1,35 @@
+﻿namespace ServiceControl.Plugin.SagaAudit
+{
+    using System;
+    using System.Threading.Tasks;
+    using NServiceBus.Pipeline;
+    using NServiceBus.Sagas;
+
+    class AuditInvokedSagaBehavior : Behavior<IInvokeHandlerContext>
+    {
+        public override async Task Invoke(IInvokeHandlerContext context, Func<Task> next)
+        {
+            await next().ConfigureAwait(false);
+
+            ActiveSagaInstance activeSagaInstance;
+
+            if (!context.Extensions.TryGet(out activeSagaInstance))
+            {
+                return;
+            }
+
+            var invokedSagaAuditData = $"{activeSagaInstance.Instance.GetType().FullName}:{activeSagaInstance.Instance.Entity.Id}";
+
+            string invokedSagasHeader;
+
+            if (context.MessageHeaders.TryGetValue(SagaAuditHeaders.InvokedSagas, out invokedSagasHeader))
+            {
+                context.Headers[SagaAuditHeaders.InvokedSagas] += $"{invokedSagasHeader};{invokedSagaAuditData}";
+            }
+            else
+            {
+                context.Headers.Add(SagaAuditHeaders.InvokedSagas, invokedSagaAuditData);
+            }
+        }
+    }
+}

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit/SagaAudit.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit/SagaAudit.cs
@@ -25,6 +25,8 @@
 
             context.Pipeline.Register("ReportSagaStateChanges", new CaptureSagaResultingMessagesBehavior(), "Reports the saga state changes to ServiceControl");
 
+            context.Pipeline.Register("AuditInvokedSaga", new AuditInvokedSagaBehavior(), "Adds audit saga information");
+
             context.RegisterStartupTask(b => new SagaAuditStartupTask(b.Build<ServiceControlBackend>()));
         }
 

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit/SagaAuditHeaders.cs
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit/SagaAuditHeaders.cs
@@ -1,0 +1,7 @@
+﻿namespace ServiceControl.Plugin.SagaAudit
+{
+    public class SagaAuditHeaders
+    {
+        public const string InvokedSagas = "NServiceBus.InvokedSagas";
+    }
+}

--- a/src/ServiceControl.Plugin.Nsb6.SagaAudit/ServiceControl.Plugin.Nsb6.SagaAudit.csproj
+++ b/src/ServiceControl.Plugin.Nsb6.SagaAudit/ServiceControl.Plugin.Nsb6.SagaAudit.csproj
@@ -59,11 +59,13 @@
     <Reference Include="System.Xml" />
   </ItemGroup>
   <ItemGroup>
+    <Compile Include="AuditInvokedSagaBehavior.cs" />
     <Compile Include="CaptureSagaResultingMessagesBehavior.cs" />
     <Compile Include="CaptureSagaStateBehavior.cs">
       <ItemGuid>be7306a9-93a4-490d-ac1a-8377f589cebe</ItemGuid>
     </Compile>
     <Compile Include="AssemblyInfo.cs" />
+    <Compile Include="SagaAuditHeaders.cs" />
     <Compile Include="SagaAuditSerializer.cs" />
     <Compile Include="Messages\SagaChangeInitiator.cs" />
     <Compile Include="Messages\SagaChangeOutput.cs" />


### PR DESCRIPTION
This addresses #12 by implementing the v5 Core behavior that has been removed in v6 and moving it to the SagaAudit plugin.
